### PR TITLE
RDF Ontology updates for R6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>1.21.0-SNAPSHOT</version>
 
     <properties>
-        <fhirCoreVersion>6.7.2-SNAPSHOT</fhirCoreVersion>
+        <fhirCoreVersion>6.7.4-SNAPSHOT</fhirCoreVersion>
         <apachePoiVersion>5.4.1</apachePoiVersion>
         <jacksonVersion>2.16.0</jacksonVersion>
         <apacheHttpcomponentsVersion>4.5.13</apacheHttpcomponentsVersion>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
         <lombok_version>1.18.38</lombok_version>
         <slf4jVersion>1.7.36</slf4jVersion>
         <jettyVersion>12.0.12</jettyVersion>
-        <logbackVersion>1.5.17</logbackVersion>
+        <logbackVersion>1.5.20</logbackVersion>
         <nettyConstrainedVersion>4.1.118.Final</nettyConstrainedVersion>
         <maven.compiler.release>17</maven.compiler.release>
         <maven.compiler.source>17</maven.compiler.source>
@@ -92,7 +92,7 @@
             <dependency>
                 <groupId>commons-beanutils</groupId>
                 <artifactId>commons-beanutils</artifactId>
-                <version>1.9.4</version>
+                <version>1.11.0</version>
             </dependency>
             <dependency>
                 <groupId>commons-io</groupId>
@@ -361,7 +361,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.16.0</version>
+            <version>3.18.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
@@ -457,7 +457,7 @@
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
             <artifactId>org.eclipse.jgit</artifactId>
-            <version>6.10.0.202406032230-r</version>
+            <version>6.10.1.202505221210-r</version>
         </dependency>
         <dependency>
             <groupId>org.fhir</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>1.21.0-SNAPSHOT</version>
 
     <properties>
-        <fhirCoreVersion>6.7.1-SNAPSHOT</fhirCoreVersion>
+        <fhirCoreVersion>6.7.2-SNAPSHOT</fhirCoreVersion>
         <apachePoiVersion>5.4.1</apachePoiVersion>
         <jacksonVersion>2.16.0</jacksonVersion>
         <apacheHttpcomponentsVersion>4.5.13</apacheHttpcomponentsVersion>

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -168,7 +168,7 @@ public class FhirTurtleGenerator {
                 .addDataProperty(RDFS.comment, "Some resources can contain other resources. Given that the relationships can appear in any order in RDF, it cannot be assumed that the first encountered element represents the resource of interest that is being represented by the set of Turtle statements. The focal resource -- where to start when parsing -- is the resource with the relationship fhir:nodeRole to fhir:treeRoot. If there is more than one node labeled as a 'treeRoot' in a set of Turtle statements, it cannot be determined how to parse them as a single resource.");
 
         FHIRResource nodeRole = fact.fhir_objectProperty("nodeRole", fhirRdfPageUrl)
-                .addTitle("Identifies role of subject in context of a given document.")
+                .addTitle("Identifies role of subject in context of a given document")
                 .domain(Resource)
                 .range(treeRoot.resource);
         Resource.restriction(fact.fhir_class_cardinality_restriction(nodeRole.resource, treeRoot.resource, 0, 1));
@@ -182,7 +182,8 @@ public class FhirTurtleGenerator {
 //        Element.restriction(fact.fhir_cardinality_restriction(index.resource, XSD.nonNegativeInteger, 0, 1));
 
         // References have an optional link
-        FHIRResource link = fact.fhir_objectProperty(fhirRdfLinkName, fhirRdfPageUrl)
+        FHIRResource link = fact.fhir_resource(fhirRdfLinkName, OWL2.ObjectProperty, "fhir:" + fhirRdfLinkName)
+                                .addProvenance(fhirRdfPageUrl)
                                 .addTitle("IRI of a reference");
         Reference.restriction(fact.fhir_class_cardinality_restriction(link.resource, Resource.resource, 0, 1));
 

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -188,7 +188,6 @@ public class FhirTurtleGenerator {
         Reference.restriction(fact.fhir_class_cardinality_restriction(link.resource, Resource.resource, 0, 1));
 
         // XHTML is an XML Literal -- but it isn't recognized by OWL so we use string
-        FHIRResource NarrativeDiv = fact.fhir_dataProperty("Narrative.div");
         String xhtmlCanonical = "http://hl7.org/fhir/StructureDefinition/xhtml";
         fact.fhir_class_with_provenance("xhtml", "PrimitiveType", xhtmlCanonical)
             .restriction(fact.fhir_class_cardinality_restriction(v, XSD.xstring, 1, 1));
@@ -217,13 +216,14 @@ public class FhirTurtleGenerator {
             }
 
             FHIRResource extensionResource = fact.fhir_class("Extension");
-            FHIRResource modifierExtensionResource = fact.fhir_class("modifierExtension", extensionResource.resource);
+
+            Resource modifierExtensionProperty = RDFNamespace.FHIR.resourceRef("modifierExtension");
 
             FHIRResource cardRestriction = fact.fhir_bnode().addType(OWL2.Restriction).addDataProperty(OWL2.minCardinality, "1", XSDDatatype.XSDinteger)
-                    .addObjectProperty(OWL2.onProperty, modifierExtensionResource);
+                    .addObjectProperty(OWL2.onProperty, modifierExtensionProperty);
             modResource.restriction(cardRestriction.resource);
             FHIRResource extRestriction = fact.fhir_bnode().addType(OWL2.Restriction)
-                    .addObjectProperty(OWL2.onProperty, modifierExtensionResource)
+                    .addObjectProperty(OWL2.onProperty, modifierExtensionProperty)
                     .addObjectProperty(OWL2.allValuesFrom, extensionResource);
             modResource.restriction(extRestriction.resource);
 

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/FhirTurtleGenerator.java
@@ -677,7 +677,6 @@ public class FhirTurtleGenerator {
             if (ed instanceof TypeDefn) {
                 StructureDefinition sdx = ((TypeDefn) ed).getProfile();
                 if (sdx != null && !Utilities.noString(sdx.getUrl())) {
-                    System.out.println("Found canonical for " + typeName + " via TypeDefn profile: " + sdx.getUrl());
                     url = sdx.getUrl();
                 }
             }

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/ProfileGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/ProfileGenerator.java
@@ -1473,20 +1473,10 @@ public class ProfileGenerator {
         throw new FHIRException("Type mismatch on common parameter: expected "+sp.getType().toCode()+" but found "+getSearchParamType(spd.getType()).toCode());
       if (!sp.getDescription().contains("["+rn+"]("+rn.toLowerCase()+".html)"))
         sp.setDescription(sp.getDescription()+"* ["+rn+"]("+rn.toLowerCase()+".html): " + spd.getDescription()+"\r\n");
-//      Extension ext = sp.addExtension().setUrl("http://hl7.org/fhir/StructureDefinition/SearchParameter-label");
-//      ext.addExtension("resource", new CodeType(spd.getDescription()));
-//      ext.addExtension("description", new MarkdownType(spd.getDescription()));
-      if (!Utilities.noString(spd.getExpression()) && !sp.getExpression().contains(spd.getExpression())) 
+      if (!Utilities.noString(spd.getExpression()) && !sp.getExpression().contains(spd.getExpression()))
         sp.setExpression(sp.getExpression()+" | "+spd.getExpression());
-//      String xpath = new XPathQueryGenerator(this.definitions, null, null).generateXpath(spd.getPaths(), rn);
-//      if (xpath != null) {
-//        if (xpath.contains("[x]"))
-//          xpath = convertToXpath(xpath);
-//        if (sp.getXpath() != null && !sp.getXpath().contains(xpath)) 
-//          sp.setXpath(sp.getXpath()+" | " +xpath);
-        if (spd.getProcessingMode() != null && sp.getProcessingMode() != spd.getProcessingMode()) 
-          throw new FHIRException("Usage mismatch on common parameter: expected "+sp.getProcessingMode().toCode()+" but found "+spd.getProcessingMode().toCode());
-//      }
+      if (spd.getProcessingMode() != null && sp.getProcessingMode() != spd.getProcessingMode())
+        throw new FHIRException("Usage mismatch on common parameter: expected "+sp.getProcessingMode().toCode()+" but found "+spd.getProcessingMode().toCode());
       SearchParameter spx = sp.copy();
       spx.getBase().clear();
       spx.addBase(VersionIndependentResourceTypesAll.fromCode(p.getType()));

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/TurtleSpecGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/TurtleSpecGenerator.java
@@ -21,44 +21,46 @@ import org.hl7.fhir.utilities.Utilities;
 
 public class TurtleSpecGenerator extends OutputStreamWriter {
 
-	private String defPage;
-	private String dtRoot;
-	private Definitions definitions;
+  private String defPage;
+  private String dtRoot;
+  private Definitions definitions;
   private PageProcessor page;
   private String prefix;
   private String version; 
 
-	public TurtleSpecGenerator(OutputStream out, String defPage, String dtRoot, PageProcessor page, String prefix, String version) throws UnsupportedEncodingException {
-		super(out, "UTF-8");
-		this.defPage = defPage;
-		this.dtRoot = dtRoot == null ? "" : dtRoot;
-		this.definitions = page.getDefinitions();
-		this.page = page;
-		this.prefix = prefix;
-		this.version = version;
-	}
+  public TurtleSpecGenerator(OutputStream out, String defPage, String dtRoot, PageProcessor page, String prefix,
+      String version) throws UnsupportedEncodingException {
+    super(out, "UTF-8");
+    this.defPage = defPage;
+    this.dtRoot = dtRoot == null ? "" : dtRoot;
+    this.definitions = page.getDefinitions();
+    this.page = page;
+    this.prefix = prefix;
+    this.version = version;
+  }
 
   protected String getBindingLink(ElementDefn e) throws Exception {
     BindingSpecification bs = e.getBinding();
     if (bs == null)
       return "terminologies.html#unbound";
     if (bs.getValueSet() != null) 
-      return bs.getValueSet().hasUserData("external.url") ? bs.getValueSet().getUserString("external.url") : bs.getValueSet().getWebPath();
+      return bs.getValueSet().hasUserData("external.url") ? bs.getValueSet().getUserString("external.url")
+          : bs.getValueSet().getWebPath();
     else if (!Utilities.noString(bs.getReference()))
       return bs.getReference();      
     else 
       return "terminologies.html#unbound";
   }
 
-	public void generate(ElementDefn root, boolean isAbstract) throws Exception {
-		write("<pre class=\"spec\">\r\n");
+  public void generate(ElementDefn root, boolean isAbstract) throws Exception {
+    write("<pre class=\"spec\">\r\n");
 
-		generateInner(root, definitions.hasResource(root.getName()), isAbstract);
+    generateInner(root, definitions.hasResource(root.getName()), isAbstract);
 
-		write("</pre>\r\n");
-		flush();
-		close();
-	}
+    write("</pre>\r\n");
+    flush();
+    close();
+  }
 
   public void generateExtension(StructureDefinition ed) throws Exception {
     write("<pre class=\"spec\">\r\n");
@@ -71,20 +73,27 @@ public class TurtleSpecGenerator extends OutputStreamWriter {
   }
 
   private void generateInner(ElementDefn root, boolean resource, boolean isAbstract) throws IOException, Exception {
-		String rn;
-		if (root.getName().equals("Extension")) 
-		  rn = "extension|modifierExtension";
-		else if (root.getName().equals("Meta")) 
+    String rn;
+    Boolean isReference = false;
+    if (root.getName().equals("Extension")) {
+      rn = "extension|modifierExtension";
+    } else if (root.getName().equals("Meta")) {
       rn = "meta";
-		else if (root.getTypes().size() > 0 && (root.getTypes().get(0).getName().equals("Type")
-				|| (root.getTypes().get(0).getName().equals("Structure"))) || isAbstract)
-			rn = "[name]";
-		else 
-			rn = root.getName();
+    } else if (root.getTypes().size() > 0 && (root.getTypes().get(0).getName().equals("Type")
+        || (root.getTypes().get(0).getName().equals("Structure"))) || isAbstract) {
+      rn = "[name]";
+    } else if (root.getName().equals("Reference")) {
+      isReference = true;
+      rn = root.getName();
+    } else {
+      rn = root.getName();
+    }
+    System.out.println("root.getName() = " + root.getName() + " => rn = " + rn + " (resource = " + resource + ")");
 
     write("@prefix fhir: &lt;http://hl7.org/fhir/&gt; .");
-    if (resource) 
-      write("<span style=\"float: right\"><a title=\"Documentation for this format\" href=\""+prefix+"rdf.html\"><img src=\""+prefix+"help.png\" alt=\"doco\"/></a></span>\r\n");
+    if (resource)
+      write("<span style=\"float: right\"><a title=\"Documentation for this format\" href=\"" + prefix
+          + "rdf.html\"><img src=\"" + prefix + "help.png\" alt=\"doco\"/></a></span>\r\n");
     write("\r\n");
     write("\r\n");
     if (resource) {
@@ -104,23 +113,39 @@ public class TurtleSpecGenerator extends OutputStreamWriter {
       write("\r\n  fhir:nodeRole fhir:treeRoot; # if this is the parser root\r\n");
     } else
       write("[");
-		write("\r\n");
+      
+    write("\r\n");
+
     if (rn.equals(root.getName()) && resource) {
+      // Resources - Not Extension or Meta or "abstract"
       if (!Utilities.noString(root.typeCode())) {
-        write("  # from <a href=\""+prefix+"resource.html\">Resource</a>: <a href=\""+prefix+"resource.html#id\">.id</a>, <a href=\""+prefix+"resource.html#meta\">.meta</a>, <a href=\""+prefix+"resource.html#implicitRules\">.implicitRules</a>, and <a href=\""+prefix+"resource.html#language\">.language</a>\r\n");
-        if (root.typeCode().equals("DomainResource") || Utilities.existsInList(root.typeCode(), definitions.getInterfaceNames())) {
-          write("  # from <a href=\""+prefix+"domainresource.html\">DomainResource</a>: <a href=\""+prefix+"narrative.html#Narrative\">.text</a>, <a href=\""+prefix+"references.html#contained\">.contained</a>, <a href=\""+prefix+"extensibility.html\">.extension</a>, and <a href=\""+prefix+"extensibility.html#modifierExtension\">.modifierExtension</a>\r\n");
+        write("  # from <a href=\"" + prefix + "resource.html\">Resource</a>: <a href=\"" + prefix
+            + "resource.html#id\">.id</a>, <a href=\"" + prefix + "resource.html#meta\">.meta</a>, <a href=\"" + prefix
+            + "resource.html#implicitRules\">.implicitRules</a>, and <a href=\"" + prefix
+            + "resource.html#language\">.language</a>\r\n");
+        if (root.typeCode().equals("DomainResource")
+            || Utilities.existsInList(root.typeCode(), definitions.getInterfaceNames())) {
+          write("  # from <a href=\"" + prefix + "domainresource.html\">DomainResource</a>: <a href=\"" + prefix
+              + "narrative.html#Narrative\">.text</a>, <a href=\"" + prefix
+              + "references.html#contained\">.contained</a>, <a href=\"" + prefix
+              + "extensibility.html\">.extension</a>, and <a href=\"" + prefix
+              + "extensibility.html#modifierExtension\">.modifierExtension</a>\r\n");
         }
       }
     } else {
       if (root.typeCode().equals("BackboneElement"))
         write(" # from BackboneElement: <a href=\""+prefix+"extensibility.html\">Element.extension</a>, <a href=\""+prefix+"extensibility.html\">BackboneElement.modifierextension</a>\r\n");
       else
-        write(" # from Element: <a href=\""+prefix+"extensibility.html\">Element.extension</a>\r\n");
+        write(" # from Element: <a href=\"" + prefix + "extensibility.html\">Element.extension</a>\r\n");
     }
-		for (ElementDefn elem : root.getElements()) {
-		  generateCoreElem(elem, 1, root.getName(), rn.equals(root.getName()) && resource);
-		}
+
+    if (isReference) {
+      write("  fhir:l [ IRI ] ; # 0..1 Direct <span style=\"color: navy\"><a href=\"" + prefix + "rdf.html#reference\">RDF link</a> to the referenced resource</span>\r\n");
+    }
+
+    for (ElementDefn elem : root.getElements()) {
+      generateCoreElem(elem, 1, root.getName(), rn.equals(root.getName()) && resource);
+    }
 
     write("]\r\n");
 	}

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/TurtleSpecGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/TurtleSpecGenerator.java
@@ -120,23 +120,23 @@ public class TurtleSpecGenerator extends OutputStreamWriter {
       // Resources - Not Extension or Meta or "abstract"
       if (!Utilities.noString(root.typeCode())) {
         write("  # from <a href=\"" + prefix + "resource.html\">Resource</a>: <a href=\"" + prefix
-            + "resource.html#id\">.id</a>, <a href=\"" + prefix + "resource.html#meta\">.meta</a>, <a href=\"" + prefix
-            + "resource.html#implicitRules\">.implicitRules</a>, and <a href=\"" + prefix
-            + "resource.html#language\">.language</a>\r\n");
+            + "resource.html#id\">fhir:id</a>, <a href=\"" + prefix + "resource.html#meta\">fhir:meta</a>, <a href=\"" + prefix
+            + "resource.html#implicitRules\">fhir:implicitRules</a>, and <a href=\"" + prefix
+            + "resource.html#language\">fhir:language</a>\r\n");
         if (root.typeCode().equals("DomainResource")
             || Utilities.existsInList(root.typeCode(), definitions.getInterfaceNames())) {
           write("  # from <a href=\"" + prefix + "domainresource.html\">DomainResource</a>: <a href=\"" + prefix
-              + "narrative.html#Narrative\">.text</a>, <a href=\"" + prefix
-              + "references.html#contained\">.contained</a>, <a href=\"" + prefix
-              + "extensibility.html\">.extension</a>, and <a href=\"" + prefix
-              + "extensibility.html#modifierExtension\">.modifierExtension</a>\r\n");
+              + "narrative.html#Narrative\">fhir:text</a>, <a href=\"" + prefix
+              + "references.html#contained\">fhir:contained</a>, <a href=\"" + prefix
+              + "extensibility.html\">fhir:extension</a>, and <a href=\"" + prefix
+              + "extensibility.html#modifierExtension\">fhir:modifierExtension</a>\r\n");
         }
       }
     } else {
       if (root.typeCode().equals("BackboneElement"))
-        write(" # from BackboneElement: <a href=\""+prefix+"extensibility.html\">Element.extension</a>, <a href=\""+prefix+"extensibility.html\">BackboneElement.modifierextension</a>\r\n");
+        write(" # from BackboneElement: <a href=\""+prefix+"extensibility.html\">fhir:extension</a>, <a href=\""+prefix+"extensibility.html\">fhir:modifierextension</a>\r\n");
       else
-        write(" # from Element: <a href=\"" + prefix + "extensibility.html\">Element.extension</a>\r\n");
+        write(" # from Element: <a href=\"" + prefix + "extensibility.html\">fhir:extension</a>\r\n");
     }
 
     if (isReference) {

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/TurtleSpecGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/TurtleSpecGenerator.java
@@ -140,7 +140,7 @@ public class TurtleSpecGenerator extends OutputStreamWriter {
     }
 
     if (isReference) {
-      write("  fhir:l [ IRI ] ; # 0..1 Direct <span style=\"color: navy\"><a href=\"" + prefix + "rdf.html#reference\">RDF link</a> to the referenced resource</span>\r\n");
+      write("  fhir:l [ <a href=\"https://www.w3.org/TR/rdf11-concepts/#section-IRIs\">IRI</a> ] ; # 0..1 Direct <span style=\"color: navy\"><a href=\"" + prefix + "rdf.html#reference\">RDF link</a> (<a href=\"https://www.w3.org/TR/turtle/#sec-iri-references\">relative</a> or absolute) to the referenced resource</span>\r\n");
     }
 
     for (ElementDefn elem : root.getElements()) {

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/TurtleSpecGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/TurtleSpecGenerator.java
@@ -88,7 +88,6 @@ public class TurtleSpecGenerator extends OutputStreamWriter {
     } else {
       rn = root.getName();
     }
-    System.out.println("root.getName() = " + root.getName() + " => rn = " + rn + " (resource = " + resource + ")");
 
     write("@prefix fhir: &lt;http://hl7.org/fhir/&gt; .");
     if (resource)

--- a/src/main/java/org/hl7/fhir/definitions/generators/specification/W5TurtleGenerator.java
+++ b/src/main/java/org/hl7/fhir/definitions/generators/specification/W5TurtleGenerator.java
@@ -59,11 +59,13 @@ public class W5TurtleGenerator {
         model.setNsPrefix(RDFNamespace.W5.getPrefix(), RDFNamespace.W5.getURI());
         model.setNsPrefix(RDFNamespace.FHIR.getPrefix(), RDFNamespace.FHIR.getURI());
 
+        String definitionCanonical = "http://hl7.org/fhir/w5";
         Ontology w5 = model.createOntology("http://hl7.org/fhir/w5.ttl");
         w5.addProperty(RDFS.label, "W5 Categorization");
         w5.addProperty(RDFS.comment, "FHIR W5 categorization is a preliminary classification of the fhir property");
         w5.addVersionInfo("FHIR W5 categorization (Preliminary)");
         w5.addProperty(OWL2.versionIRI, ResourceFactory.createResource(getOntologyVersionIRI()+"w5.ttl"));
+        w5.addProperty(RDFS.isDefinedBy, definitionCanonical);
 
         // The only way to differentiate predicates from classes is the existence of subclasses -- if something
         // has subclasses or is a subclass then it is a class.  Otherwise it is a predicate...
@@ -90,16 +92,19 @@ public class W5TurtleGenerator {
                 OntClass ec = model.createClass(RDFNamespace.W5.uriFor(es));
                 ec.addLabel(es, null);
                 ec.addComment(e.getDescription(), null);
+                ec.addProperty(RDFS.isDefinedBy, definitionCanonical);
                 for (String s : e.getSubClasses()) {
                     String s_uri = RDFNamespace.W5.uriFor(s.contains(".")? s : e.getCode() + "." + s);
                     OntClass c = model.createClass(s_uri);
                     c.addSuperClass(ec);
                     c.addLabel(s, null);
+                    c.addProperty(RDFS.isDefinedBy, definitionCanonical);
                 }
             } else {
                 OntProperty ep = model.createObjectProperty(RDFNamespace.W5.uriFor(es));
                 ep.addLabel(es, null);
                 ep.addComment(e.getDescription(), null);
+                ep.addProperty(RDFS.isDefinedBy, definitionCanonical);
                 String esroot = es;
                 while(esroot.contains(".")) {
                     esroot = esroot.substring(0, esroot.lastIndexOf('.'));

--- a/src/main/java/org/hl7/fhir/definitions/model/PrimitiveType.java
+++ b/src/main/java/org/hl7/fhir/definitions/model/PrimitiveType.java
@@ -114,7 +114,7 @@ public class PrimitiveType extends DefinedCode {
     if (s.equals("integer"))
       return "Integer";
     if (s.equals("integer64"))
-      return "Integer"; // see https://chat.fhir.org/#narrow/stream/179266-fhirpath/topic/Integer64
+      return "Long"; // see https://chat.fhir.org/#narrow/stream/179266-fhirpath/topic/Integer64
     if (s.equals("decimal"))
       return "Decimal";
     

--- a/src/main/java/org/hl7/fhir/rdf/FHIRResource.java
+++ b/src/main/java/org/hl7/fhir/rdf/FHIRResource.java
@@ -89,6 +89,27 @@ public class FHIRResource {
         return this;
     }
 
+    public FHIRResource addProvenance(String structureDefinitionCanonicalUrl) {
+        if (!Utilities.noString(structureDefinitionCanonicalUrl)) {
+            resource.addProperty(RDFS.isDefinedBy, ResourceFactory.createResource(structureDefinitionCanonicalUrl));
+        }
+        return this;
+    }
+
+    public FHIRResource addProvenance(Resource provenance) {
+        if (provenance != null) {
+            resource.addProperty(RDFS.isDefinedBy, provenance);
+        }
+        return this;
+    }
+
+    public FHIRResource addProvenance(FHIRResource provenance) {
+        if (provenance != null) {
+            resource.addProperty(RDFS.isDefinedBy, provenance.resource);
+        }
+        return this;
+    }
+
     public FHIRResource domain(FHIRResource d) {
         return addObjectProperty(RDFS.domain, d);
     }

--- a/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
+++ b/src/main/java/org/hl7/fhir/rdf/FHIRResourceFactory.java
@@ -20,7 +20,7 @@ public class FHIRResourceFactory {
 
     public FHIRResourceFactory() {
         model = ModelFactory.createDefaultModel();
-        RDFNamespace.addFHIRNamespaces(model);
+        RDFNamespace.addOntologyNamespaces(model);
     }
 
     /**

--- a/src/main/java/org/hl7/fhir/rdf/RDFNamespace.java
+++ b/src/main/java/org/hl7/fhir/rdf/RDFNamespace.java
@@ -23,7 +23,7 @@ public class RDFNamespace {
      */
     public static final RDFNamespace FHIR = new RDFNamespace("fhir", "http://hl7.org/fhir/");
     public static final RDFNamespace FHIR_VS = new RDFNamespace("fhirvs", "http://hl7.org/fhir/ValueSet/");
-    public static final RDFNamespace EX = new RDFNamespace("fhirsd", "http://hl7.org/fhir/StructureDefinition/");
+    public static final RDFNamespace FHIR_SD = new RDFNamespace("fhirsd", "http://hl7.org/fhir/StructureDefinition/");
     public static final RDFNamespace RIM = new RDFNamespace("rim", "http://hl7.org/owl/rim/");
     public static final RDFNamespace CS = new RDFNamespace("cs", "http://hl7.org/orim/codesystem/");
     public static final RDFNamespace VS = new RDFNamespace("vs", "http://hl7.org/orim/valueset/");
@@ -51,22 +51,14 @@ public class RDFNamespace {
      *
      * @param model model to add namespaces to
      */
-    public static void addFHIRNamespaces(Model model) {
+    public static void addOntologyNamespaces(Model model) {
         model.setNsPrefix("rdf", RDF.getURI());
         model.setNsPrefix("rdfs", RDFS.getURI());
         FHIR.addNsPrefix(model);
         W5.addNsPrefix(model);
-        FHIR_VS.addNsPrefix(model);
-        EX.addNsPrefix(model);
+        FHIR_SD.addNsPrefix(model);
         model.setNsPrefix("xsd", XSD.getURI());
         model.setNsPrefix("owl", OWL2.getURI());
-        model.setNsPrefix("dc", DC_11.getURI());
-        model.setNsPrefix("dcterms", DCTerms.getURI());
-        RIM.addNsPrefix(model);
-        CS.addNsPrefix(model);
-        VS.addNsPrefix(model);
-        DT.addNsPrefix(model);
-        LOINC.addNsPrefix(model);
     }
 
     public String getPrefix() {

--- a/src/main/java/org/hl7/fhir/rdf/RDFNamespace.java
+++ b/src/main/java/org/hl7/fhir/rdf/RDFNamespace.java
@@ -29,7 +29,7 @@ public class RDFNamespace {
     public static final RDFNamespace VS = new RDFNamespace("vs", "http://hl7.org/orim/valueset/");
     public static final RDFNamespace DT = new RDFNamespace("dt", "http://hl7.org/orim/datatype/");
     public static final RDFNamespace LOINC = new RDFNamespace("loinc", "http://loinc.org/rdf#");
-    public static final RDFNamespace W5 = new RDFNamespace("w5", "http://hl7.org/fhir/w5#");
+    public static final RDFNamespace W5 = new RDFNamespace("fhirw5", "http://hl7.org/fhir/w5#");
     // For some reason these aren't included in the XSD and RDF namespaces -- do we need to update Jena library?
     public static final Property XSDpattern;
     public static final Resource RDFXMLLiteral;

--- a/src/main/java/org/hl7/fhir/rdf/RDFNamespace.java
+++ b/src/main/java/org/hl7/fhir/rdf/RDFNamespace.java
@@ -59,6 +59,7 @@ public class RDFNamespace {
         FHIR_SD.addNsPrefix(model);
         model.setNsPrefix("xsd", XSD.getURI());
         model.setNsPrefix("owl", OWL2.getURI());
+        model.setNsPrefix("dc", DC_11.getURI());
     }
 
     public String getPrefix() {

--- a/src/main/java/org/hl7/fhir/rdf/RDFNamespace.java
+++ b/src/main/java/org/hl7/fhir/rdf/RDFNamespace.java
@@ -22,8 +22,8 @@ public class RDFNamespace {
      *  FHIR specific namespaces
      */
     public static final RDFNamespace FHIR = new RDFNamespace("fhir", "http://hl7.org/fhir/");
-    public static final RDFNamespace FHIR_VS = new RDFNamespace("fhir-vs", "http://hl7.org/fhir/ValueSet/");
-    public static final RDFNamespace EX = new RDFNamespace("ex", "http://hl7.org/fhir/StructureDefinition/");
+    public static final RDFNamespace FHIR_VS = new RDFNamespace("fhirvs", "http://hl7.org/fhir/ValueSet/");
+    public static final RDFNamespace EX = new RDFNamespace("fhirsd", "http://hl7.org/fhir/StructureDefinition/");
     public static final RDFNamespace RIM = new RDFNamespace("rim", "http://hl7.org/owl/rim/");
     public static final RDFNamespace CS = new RDFNamespace("cs", "http://hl7.org/orim/codesystem/");
     public static final RDFNamespace VS = new RDFNamespace("vs", "http://hl7.org/orim/valueset/");

--- a/src/main/java/org/hl7/fhir/tools/publisher/HTMLLinkChecker.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/HTMLLinkChecker.java
@@ -193,9 +193,12 @@ public class HTMLLinkChecker implements FileNotifier {
       src = FileUtilities.fileToString(Utilities.path(page.getFolders().dstDir, filename));
       if (!src.contains("<!--!ns!-->") && !src.contains("<!-- !ns! -->"))
         reportError(filename, "File "+filename+" has no normative marker");
-      if ((src.contains("may not") || src.contains("May not")) && !(src.contains("Apache") || src.contains("TemplateStatusCode"))) // those words appear in the Apache license
-        if (!filename.contains("v2"+File.separator) && !filename.contains("v3"+File.separator) && !filename.contains("dicom") && !src.contains("http://terminology.hl7.org/CodeSystem/v3-") && !Utilities.existsInList(filename, "terminologies-valuesets.html"))
-          reportError(filename, "File "+filename+" contains the prohibited words 'may not' - use 'might not' or 'SHALL not', or if the content is external, talk to the FHIR product Director");
+      if ((src.contains("may not") || src.contains("May not")) && !(src.contains("Apache") || src.contains("TemplateStatusCode"))) { // those words appear in the Apache license
+        if (!src.contains("This expansion generated")) { // ignore expansions
+          if (!filename.contains("v2" + File.separator) && !filename.contains("v3" + File.separator) && !filename.contains("dicom") && !src.contains("http://terminology.hl7.org/CodeSystem/v3-") && !Utilities.existsInList(filename, "terminologies-valuesets.html"))
+            reportError(filename, "File " + filename + " contains the prohibited words 'may not' - use 'might not' or 'SHALL not', or if the content is external, talk to the FHIR product Director");
+        }
+      }
 //      if (src.contains("should"))
 //        reportError(filename, "File "+filename+" contains the word 'should'. Make it uppercase, or if the content is external, talk to FHIR product Director");
     } catch (Exception e) {

--- a/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
@@ -8148,7 +8148,7 @@ public class PageProcessor implements Logger, ProfileKnowledgeProvider, IReferen
     }
     b.append("</td><td>");
     b.append(processMarkdown(resource, p.getDoc(), prefix));
-    if (p.getName().equals("return") && isOnlyOutParameter(op.getParameters(), p) && isRes)
+    if (p.getName().equals("return") && isOnlyOutParameter(op.getParameters(), p) && "1".equals(p.getMax()) && isRes)
       b.append("<p>Note: as this is the only out parameter, it is a resource, and it has the name 'return', the result of this operation is returned directly as a resource</p>");
     b.append("</td></tr>");
     for (OperationParameter pp : p.getParts())

--- a/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
+++ b/src/main/java/org/hl7/fhir/tools/publisher/PageProcessor.java
@@ -128,6 +128,7 @@ import org.hl7.fhir.r5.conformance.profile.BindingResolution;
 import org.hl7.fhir.r5.conformance.profile.ProfileKnowledgeProvider;
 import org.hl7.fhir.r5.conformance.profile.ProfileUtilities;
 import org.hl7.fhir.r5.context.CanonicalResourceManager;
+import org.hl7.fhir.r5.context.ExpansionOptions;
 import org.hl7.fhir.r5.context.ILoggingService;
 import org.hl7.fhir.r5.elementmodel.Element;
 import org.hl7.fhir.r5.elementmodel.Manager;
@@ -2342,7 +2343,7 @@ public class PageProcessor implements Logger, ProfileKnowledgeProvider, IReferen
         if (vs.hasUserData("expansion"))
           evs = (ValueSet) vs.getUserData("expansion");
         else {
-          ValueSetExpansionOutcome vse = getWorkerContext().expandVS(vs, true, false, true);
+          ValueSetExpansionOutcome vse = getWorkerContext().expandVS(ExpansionOptions.cacheNoHeirarchy().withIncompleteOk(true), vs);
           if (vse.getValueset() != null) {
             evs = vse.getValueset();
             vs.setUserData("expansion", evs);
@@ -11424,7 +11425,7 @@ public class PageProcessor implements Logger, ProfileKnowledgeProvider, IReferen
   public String expandVS(ValueSet vs, String prefix, String base) {
     try {
 
-      ValueSetExpansionOutcome result = workerContext.expandVS(vs, true, true, true);
+      ValueSetExpansionOutcome result = workerContext.expandVS(ExpansionOptions.cacheNoHeirarchy().withIncompleteOk(true), vs);
       if (result.getError() != null)
         return "<hr/>\r\n"+VS_INC_START+"<!--3-->"+processExpansionError(result.getError())+VS_INC_END;
 


### PR DESCRIPTION
### 1. Update `fhir:link` to `fhir:l` & apply to `fhir:canonical` references https://github.com/w3c/hcls-fhir-rdf/issues/120
* Update object property name and yellow schema template for `fhir:Reference`

This should go in with https://github.com/hapifhir/org.hl7.fhir.core/pull/2194

### 2. Annotate FHIR ontology classes with provenance https://github.com/w3c/hcls-fhir-rdf/issues/133
* Every class is annotated with `rdfs:isDefinedBy` pointing to the StructureDefinition that defines it. Every object property and BackboneElement used in a StructureDefinition also uses the same annotation. We use `fhirsd:` as the prefix for http://hl7.org/fhir/StructureDefinition/, consistent with `fhirvs:` used in ShEx for http://hl7.org/fhir/ValueSet
  * Example:
```turtle
@prefix fhir:    <http://hl7.org/fhir/> .
@prefix fhirsd:  <http://hl7.org/fhir/StructureDefinition/> .

fhir:Encounter  rdf:type  owl:Class;
        rdfs:isDefinedBy  fhirsd:Encounter;

fhir:EncounterReason  rdf:type  owl:Class;
        rdfs:isDefinedBy  fhirsd:Encounter

fhir:reason  rdf:type  owl:ObjectProperty;
        rdfs:isDefinedBy  fhirsd:Encounter;
```

* `fhir:v` , `fhir:l`, `fhir:treeRoot`, and `fhir:nodeRole` are annotated with `rdfs:isDefinedBy` https://www.hl7.org/fhir/rdf.html 


### 3. Hierarchy fixes https://github.com/w3c/hcls-fhir-rdf/issues/179
* Removed duplicate `fhir:Primitive` class & reclassified primitive types under `fhir:PrimitiveType` which is a `fhir:DataType` and `fhir:Base`

* Removed duplicate `fhir:value` object property, which instead was named `fhir:v` in R5

### 4. Reference types and choice types https://github.com/w3c/hcls-fhir-rdf/issues/177
* Added target types for references, requiring that they be instances of `fhir:Reference` (or `fhir:canonical` or `fhir:CodeableReference`) and also their `fhir:l` value must be an instance of a union of type classes. This is already represented in the published FHIR ShEx schemas https://build.fhir.org/fhir.shex
```manchester syntax
subject only 
    (Reference
     and (l only 
        (Group or Patient)))
```
* Fixed `owl:unionOf` axioms to remove erroneous and duplicate cardinality restrictions 
